### PR TITLE
Enable `TLSComponent`, `HTTPComponent`, `DNSComponent` for new Censys SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ cython_debug/
 .idea
 
 /test_data/test.json
+.vscode/*

--- a/common_osint_model/models/dns.py
+++ b/common_osint_model/models/dns.py
@@ -2,6 +2,8 @@ from pydantic import BaseModel
 from typing import Optional, Dict
 from common_osint_model.models import ShodanDataHandler, CensysDataHandler
 
+from censys_platform.models import Service as CensysService
+
 
 class DNSComponent(BaseModel, ShodanDataHandler, CensysDataHandler):
     recursive: Optional[bool] = None
@@ -13,7 +15,14 @@ class DNSComponent(BaseModel, ShodanDataHandler, CensysDataHandler):
         )
 
     @classmethod
-    def from_censys(cls, d: Dict):
-        return DNSComponent(
-            recursive=d.get("dns", {}).get("server_type", "") == "FORWARDING"
-        )
+    def from_censys(cls, service: Dict | CensysService):
+        if isinstance(service, CensysService):
+            if service.dns is not None:
+                return DNSComponent(
+                    recursive=service.dns.server_type == "FORWARDING"
+                )
+            return None
+        if isinstance(service, Dict):
+            return DNSComponent(
+                recursive=service.get("dns", {}).get("server_type", "") == "FORWARDING"
+            )

--- a/common_osint_model/models/http.py
+++ b/common_osint_model/models/http.py
@@ -13,6 +13,8 @@ from common_osint_model.models import (
 )
 from common_osint_model.utils import hash_all
 
+from censys_platform.models import Service as CensysService
+
 
 class HTTPComponentContentFavicon(
     BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDataHandler, Logger
@@ -273,7 +275,47 @@ class HTTPComponent(
         )
 
     @classmethod
-    def from_censys(cls, d: Dict):
+    def from_censys(cls, service: Dict | CensysService):
+        if isinstance(service, CensysService):
+            for endpoint in service.endpoints:
+                if endpoint.http is not None:
+                    headers:Dict[str,str] = dict()
+                    # Store Header
+                    for header_name, header_values in endpoint.http.headers:
+                        for header_value in header_values:
+                            headers[header_name] = header_value
+                    banner_lines = service.banner.replace("\r", "").split("\n")
+                    banner_keys = banner_lines[0]
+                    for line in banner_lines:
+                        if ":" in line:
+                            k, _ = line.split(":", maxsplit=1)
+                            banner_keys += "\n" + k
+                    headers_hash = str(mmh3.hash(banner_keys.encode("utf-8")))
+
+                    return HTTPComponent(
+                        headers=headers,
+                        # TODO: Implement HTTPComponentContent
+                        #content=HTTPComponentContent.from_censys(d),
+                        content=None,
+                        shodan_headers_hash=headers_hash,
+                        hhhash=hash_from_banner(service.banner),
+                    )
+            # Fallback, if no endpoint or no HTTP endpoint
+            return None
+
+        if isinstance(service, Dict):
+            return cls._from_censys_dict(d=service)
+
+    @classmethod
+    def from_binaryedge(cls, d: Union[Dict, List]):
+        http_response = d["result"]["data"]["response"]
+        headers = http_response["headers"]["headers"]
+        return HTTPComponent(
+            headers=headers, content=HTTPComponentContent.from_binaryedge(d)
+        )
+
+    @classmethod
+    def _from_censys_dict(cls, d: Dict):
         """Todo: Is parsing from services.banner better than just looping over the headers found by Censys?"""
         http = d["http"]["response"]
         headers = {}
@@ -296,12 +338,4 @@ class HTTPComponent(
             content=HTTPComponentContent.from_censys(d),
             shodan_headers_hash=headers_hash,
             hhhash=hash_from_banner(d["banner"]),
-        )
-
-    @classmethod
-    def from_binaryedge(cls, d: Union[Dict, List]):
-        http_response = d["result"]["data"]["response"]
-        headers = http_response["headers"]["headers"]
-        return HTTPComponent(
-            headers=headers, content=HTTPComponentContent.from_binaryedge(d)
         )

--- a/common_osint_model/models/http.py
+++ b/common_osint_model/models/http.py
@@ -216,7 +216,6 @@ class HTTPComponentContent(
                     if endpoint.http.body_hash_sha256 is not None:
                         sha256 = endpoint.http.body_hash_sha256
                     
-                    # TODO: Implement Favicon, Robots, Security
                     return HTTPComponentContent(
                         raw=http_body,
                         length=len(http_body),
@@ -224,6 +223,7 @@ class HTTPComponentContent(
                         sha1=sha1,
                         sha256=sha256,
                         murmur=murmur,
+                        # TODO: Implement Favicon, Robots, Security
                         #favicon=HTTPComponentContentFavicon.from_censys(service),
                         #robots_txt=HTTPComponentContentRobots.from_censys(service),
                         #security_txt=HTTPComponentContentSecurity.from_censys(service),

--- a/common_osint_model/models/http.py
+++ b/common_osint_model/models/http.py
@@ -282,7 +282,7 @@ class HTTPComponent(
                     headers:Dict[str,str] = dict()
                     # Store Header
                     for header_name, header_values in endpoint.http.headers.items():
-                        for header_value in header_values:
+                        for header_value in header_values.headers:
                             headers[header_name] = header_value
                     banner_lines = service.banner.replace("\r", "").split("\n")
                     banner_keys = banner_lines[0]

--- a/common_osint_model/models/http.py
+++ b/common_osint_model/models/http.py
@@ -204,22 +204,49 @@ class HTTPComponentContent(
         )
 
     @classmethod
-    def from_censys(cls, d: Dict):
-        """Creates an instance of this class based on Censys (2.0) data given as dictionary."""
-        http = d["http"]["response"]
-        raw = http["body"] if http["body_size"] > 0 else ""
-        md5, sha1, sha256, murmur = hash_all(raw.encode("utf-8"))
-        return HTTPComponentContent(
-            raw=raw,
-            length=len(raw),
-            md5=md5,
-            sha1=sha1,
-            sha256=sha256,
-            murmur=murmur,
-            favicon=HTTPComponentContentFavicon.from_censys(d),
-            robots_txt=HTTPComponentContentRobots.from_censys(d),
-            security_txt=HTTPComponentContentSecurity.from_censys(d),
-        )
+    def from_censys(cls, service: Dict | CensysService):
+        if isinstance(service, CensysService):
+            for endpoint in service.endpoints:
+                if endpoint.http is not None:
+                    http_body = endpoint.http.body
+                    md5, sha1, sha256, murmur = hash_all(http_body.encode("utf-8"))
+                    # Overwrite available hashes with CensysAPI data
+                    if endpoint.http.body_hash_sha1 is not None:
+                        sha1 = endpoint.http.body_hash_sha1
+                    if endpoint.http.body_hash_sha256 is not None:
+                        sha256 = endpoint.http.body_hash_sha256
+                    
+                    # TODO: Implement Favicon, Robots, Security
+                    return HTTPComponentContent(
+                        raw=http_body,
+                        length=len(http_body),
+                        md5=md5,
+                        sha1=sha1,
+                        sha256=sha256,
+                        murmur=murmur,
+                        #favicon=HTTPComponentContentFavicon.from_censys(service),
+                        #robots_txt=HTTPComponentContentRobots.from_censys(service),
+                        #security_txt=HTTPComponentContentSecurity.from_censys(service),
+                    )
+            # Fallback, if no endpoint or no HTTP endpoint
+            return None
+
+        if isinstance(service, Dict):
+            """Creates an instance of this class based on Censys (2.0) data given as dictionary."""
+            http = service["http"]["response"]
+            raw = http["body"] if http["body_size"] > 0 else ""
+            md5, sha1, sha256, murmur = hash_all(raw.encode("utf-8"))
+            return HTTPComponentContent(
+                raw=raw,
+                length=len(raw),
+                md5=md5,
+                sha1=sha1,
+                sha256=sha256,
+                murmur=murmur,
+                favicon=HTTPComponentContentFavicon.from_censys(service),
+                robots_txt=HTTPComponentContentRobots.from_censys(service),
+                security_txt=HTTPComponentContentSecurity.from_censys(service),
+            )
 
     @classmethod
     def from_binaryedge(cls, d: Union[Dict, List]):
@@ -248,6 +275,7 @@ class HTTPComponent(
     content: Optional[HTTPComponentContent] = None
     shodan_headers_hash: Optional[str] = None
     hhhash: Optional[str] = None
+    status_code: Optional[int] = None
 
     @classmethod
     def from_shodan(cls, d: Dict):
@@ -294,11 +322,10 @@ class HTTPComponent(
 
                     return HTTPComponent(
                         headers=headers,
-                        # TODO: Implement HTTPComponentContent
-                        #content=HTTPComponentContent.from_censys(d),
-                        content=None,
+                        content=HTTPComponentContent.from_censys(service),
                         shodan_headers_hash=headers_hash,
                         hhhash=hash_from_banner(service.banner),
+                        status_code=endpoint.http.status_code
                     )
             # Fallback, if no endpoint or no HTTP endpoint
             return None

--- a/common_osint_model/models/http.py
+++ b/common_osint_model/models/http.py
@@ -281,7 +281,7 @@ class HTTPComponent(
                 if endpoint.http is not None:
                     headers:Dict[str,str] = dict()
                     # Store Header
-                    for header_name, header_values in endpoint.http.headers:
+                    for header_name, header_values in endpoint.http.headers.items():
                         for header_value in header_values:
                             headers[header_name] = header_value
                     banner_lines = service.banner.replace("\r", "").split("\n")

--- a/common_osint_model/models/service.py
+++ b/common_osint_model/models/service.py
@@ -119,6 +119,10 @@ class Service(
             tls = None
             if service.tls is not None:
                 tls = TLSComponent.from_censys(service=service)
+            
+            http = None
+            if service.endpoints is not None:
+                http = HTTPComponent.from_censys(service=service)
 
             # TODO: Implement TLSComponent, HTTPComponent, DNSComponent, SSHComponent
 
@@ -140,6 +144,7 @@ class Service(
                 ja4tscan=ja4tscan,
                 timestamp=timestamp,
                 tls=tls,
+                http=http,
                 source="censys"
             )
 

--- a/common_osint_model/models/service.py
+++ b/common_osint_model/models/service.py
@@ -124,7 +124,11 @@ class Service(
             if service.endpoints is not None:
                 http = HTTPComponent.from_censys(service=service)
 
-            # TODO: Implement TLSComponent, HTTPComponent, DNSComponent, SSHComponent
+            dns = None
+            if service.dns is not None:
+                dns = DNSComponent.from_censys(service=service)
+            
+            # TODO: Implement SSHComponent
 
             timestamp = None
             try:
@@ -145,6 +149,7 @@ class Service(
                 timestamp=timestamp,
                 tls=tls,
                 http=http,
+                dns=dns,
                 source="censys"
             )
 

--- a/common_osint_model/models/service.py
+++ b/common_osint_model/models/service.py
@@ -115,6 +115,10 @@ class Service(
             ja4tscan = None
             if service.ja4tscan is not None:
                 ja4tscan = service.ja4tscan.fingerprint
+            
+            tls = None
+            if service.tls is not None:
+                tls = TLSComponent.from_censys(service=service)
 
             # TODO: Implement TLSComponent, HTTPComponent, DNSComponent, SSHComponent
 
@@ -135,6 +139,7 @@ class Service(
                 murmur=murmur,
                 ja4tscan=ja4tscan,
                 timestamp=timestamp,
+                tls=tls,
                 source="censys"
             )
 

--- a/common_osint_model/models/tls.py
+++ b/common_osint_model/models/tls.py
@@ -365,7 +365,9 @@ class TLSComponent(BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDa
                 certificate = None
                 ja3s = tls.ja3s
                 ja4s = tls.ja4s
-                jarm = service.jarm.fingerprint
+                jarm = None
+                if service.jarm is not None:
+                    jarm = service.jarm.fingerprint
                 return TLSComponent(
                     certificate=certificate,
                     ja3s=ja3s,

--- a/common_osint_model/models/tls.py
+++ b/common_osint_model/models/tls.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel
 
 from common_osint_model.models import ShodanDataHandler, CensysDataHandler, BinaryEdgeDataHandler, Logger
 
+from censys_platform.models import Service as CensysService
+
 
 class TLSComponentCertificateEntity(BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDataHandler, Logger):
     """Represents certificate entities, typically issuer and subject."""
@@ -336,10 +338,10 @@ class TLSComponent(BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDa
     certificate: Optional[TLSComponentCertificate] = None
     ja3: Optional[str] = None
     ja3s: Optional[str] = None
+    ja4s: Optional[str] = None
     jarm: Optional[str] = None
 
     # Todo: Add other attributes relevant to TLS such as CipherSuits etc.
-    # Todo: Add JA4S
 
     @classmethod
     def from_shodan(cls, d: Dict):
@@ -355,18 +357,35 @@ class TLSComponent(BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDa
         )
 
     @classmethod
-    def from_censys(cls, d: Dict):
-        try:
-            tls = d["tls"]
-            return TLSComponent(
-                certificate=TLSComponentCertificate.from_censys(tls["certificates"]["leaf_data"]),
-                ja3s=tls.get("ja3s", None),
-                jarm=d.get("jarm", {}).get("fingerprint", None)
-            )
-        except KeyError as e:
-            cls.error(f"Exception during certificate data extraction. "
-                      f"The key 'tls.certificates.leaf_data' is not available: {e}\nReturning None...")
-            return None
+    def from_censys(cls, service: Dict | CensysService):
+        if isinstance(service, CensysService):
+            if service.tls is not None:
+                tls = service.tls
+                # TODO: Implement TLSComponentCertificate
+                certificate = None
+                ja3s = tls.ja3s
+                ja4s = tls.ja4s
+                jarm = service.jarm.fingerprint
+                return TLSComponent(
+                    certificate=certificate,
+                    ja3s=ja3s,
+                    ja4s=ja4s,
+                    jarm=jarm
+                )
+            else:
+                return None
+        if isinstance(service, Dict):
+            try:
+                tls = service["tls"]
+                return TLSComponent(
+                    certificate=TLSComponentCertificate.from_censys(tls["certificates"]["leaf_data"]),
+                    ja3s=tls.get("ja3s", None),
+                    jarm=service.get("jarm", {}).get("fingerprint", None)
+                )
+            except KeyError as e:
+                cls.error(f"Exception during certificate data extraction. "
+                        f"The key 'tls.certificates.leaf_data' is not available: {e}\nReturning None...")
+                return None
 
     @classmethod
     def from_binaryedge(cls, d: Union[Dict, List]):

--- a/common_osint_model/models/tls.py
+++ b/common_osint_model/models/tls.py
@@ -178,7 +178,7 @@ class TLSComponentCertificateEntity(BaseModel, ShodanDataHandler, CensysDataHand
             email=email
         )
 
-
+# TODO: Implement Certificate
 class TLSComponentCertificate(BaseModel, ShodanDataHandler, CensysDataHandler, BinaryEdgeDataHandler, Logger):
     """Represents certificates."""
     issuer: Optional[TLSComponentCertificateEntity] = None

--- a/tests/test_censys_dict.py
+++ b/tests/test_censys_dict.py
@@ -11,6 +11,9 @@ def test_quad_one_file_success():
         host = Host.from_censys(json.loads(censys_file.read()))
         assert host.ip == "1.1.1.1"
         assert host.services[2].tls.ja3s == "d75f9129bb5d05492a65ff78e081bcb2"
+        assert "Content-Type" in host.services[1].http.headers.keys()
+        assert host.services[1].http.headers.get("Location") == "https://1.1.1.1/application/notifications_redirections"
+        assert len(host.services[1].http.headers.keys()) == 7
 
 def test_host_mock_success():
     host = Host.from_censys(CENSYS_HOST_JSON_LEGACY)

--- a/tests/test_censys_dict.py
+++ b/tests/test_censys_dict.py
@@ -19,6 +19,7 @@ def test_host_mock_success():
     host = Host.from_censys(CENSYS_HOST_JSON_LEGACY)
     assert host.ip == "8.8.8.8"
     assert host.services[0].port == 53
+    assert host.services[0].dns.recursive == True
 
 def test_quad_nine_file_success():
     file:pathlib.Path = pathlib.Path.cwd() / "test_data" / "9.9.9.9_censys_v2.json"

--- a/tests/test_censys_dict.py
+++ b/tests/test_censys_dict.py
@@ -10,6 +10,7 @@ def test_quad_one_file_success():
     with open(file, "r") as censys_file:
         host = Host.from_censys(json.loads(censys_file.read()))
         assert host.ip == "1.1.1.1"
+        assert host.services[2].tls.ja3s == "d75f9129bb5d05492a65ff78e081bcb2"
 
 def test_host_mock_success():
     host = Host.from_censys(CENSYS_HOST_JSON_LEGACY)


### PR DESCRIPTION
For the new version of the Censys SDK, I added the following components of `Service`:
- `TLSComponent` (for now without certificate information)
- `HTTPComponent` (including `HTTPComponentContent`)
- `DNSComponent`

I also added the
- `HTTPComponent`: field "status_code" for storing the HTTP status code
- `TLSComponent`: field "ja4s" for storing this value
